### PR TITLE
Add string enum for No-yes list property string value

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -14,6 +14,10 @@ declare enum PropertyType {
     Regex = "regex",
     OAuthToken = "oauthtoken"
 }
+declare enum NoYesListPropertyStringValue {
+    No = "No",
+    Yes = "Yes",
+}
 declare enum LogLevel {
     Info = "info",
     Warning = "warning",


### PR DESCRIPTION
When checking the value of a No-yes list property editor you currently have to check the returned string value against `"Yes"` or `"No"` as per below:
```
if (await flowElement.getPropertyStringValue("PropertyTag1") === "Yes") {
  ...
}

if (await flowElement.getPropertyStringValue("PropertyTag2") === "No") {
  ...
}
```
This leads to a lot of magic strings throughout multiple scripts checking against `"Yes"` or `"No"`. It would be much cleaner if there was an string enum included in the typings and to check against that instead as per the sample below:
```
if (await flowElement.getPropertyStringValue("PropertyTag1") === NoYesListPropertyStringValue.Yes) {
  ...
}

if (await flowElement.getPropertyStringValue("PropertyTag2") === NoYesListPropertyStringValue.No) {
  ...
}
```